### PR TITLE
 Remove overriden addFlash method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ php:
   - 7.2
 
 before_script:
+  - export COMPOSER_MEMORY_LIMIT=-1
+  - phpenv config-rm xdebug.ini
   - composer install -n
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 before_script:
   - composer install -n

--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -192,17 +192,6 @@ class DefaultController extends Controller
     }
 
     /**
-     * Helper for adding flash messages
-     *
-     * @param string $type
-     * @param string $message
-     */
-    protected function addFlash($type, $message)
-    {
-        $this->container->get('session')->getFlashBag()->add($type, $message);
-    }
-
-    /**
      * @return RedirectResponse
      */
     private function createRedirectToFeatureListReponse()


### PR DESCRIPTION
Fixes this deprecation warning for Symfony3.4+

```
User Deprecated: The
"Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait::addFlash()"
method is considered final since version 3.4. It may change without
further notice as of its next major version. You should not extend it
from "Opensoft\RolloutBundle\Controller\DefaultController"
```