### PR TITLE
Support auto-wiring and fix deprecations (Bundle will now support Symfony 3.4 and Symfony 4.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 before_script:
   - composer install -n

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ php:
   - 7.2
 
 before_script:
+  - export COMPOSER_MEMORY_LIMIT=-1
+  - phpenv config-rm xdebug.ini
   - composer install -n
 
 script:

--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -4,7 +4,7 @@ namespace Opensoft\RolloutBundle\Controller;
 
 use Opensoft\RolloutBundle\Rollout\GroupDefinitionAwareRollout;
 use Opensoft\RolloutBundle\Rollout\UserProviderInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @author Richard Fullmer <richard.fullmer@opensoftdev.com>
  */
-class DefaultController extends Controller
+class DefaultController extends AbstractController
 {
     /**
      * @var GroupDefinitionAwareRollout
@@ -203,7 +203,7 @@ class DefaultController extends Controller
 
         if ($requestParam === null) {
             $this->addFlash('danger', 'Missing "requestParam" value');
-            
+
             return $this->redirectToRoute('opensoft_rollout');
         }
 

--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -3,6 +3,7 @@
 namespace Opensoft\RolloutBundle\Controller;
 
 use Opensoft\Rollout\Rollout;
+use Opensoft\RolloutBundle\Rollout\GroupDefinitionAwareRollout;
 use Opensoft\RolloutBundle\Rollout\UserProviderInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -15,198 +16,209 @@ use Symfony\Component\HttpFoundation\Response;
 class DefaultController extends Controller
 {
     /**
+     * @param GroupDefinitionAwareRollout $rollout
+     *
      * @return Response
      */
-    public function indexAction()
+    public function indexAction(GroupDefinitionAwareRollout $rollout)
     {
-        return $this->container->get('templating')->renderResponse('OpensoftRolloutBundle:Default:index.html.twig', array('rollout' => $this->getRollout()));
+        return $this->render('OpensoftRolloutBundle:Default:index.html.twig', array('rollout' => $rollout));
     }
 
     /**
-     * @param  string           $feature
+     * @param GroupDefinitionAwareRollout $rollout
+     * @param string $feature
+     *
      * @return RedirectResponse
      */
-    public function activateAction($feature)
+    public function activateAction(GroupDefinitionAwareRollout $rollout, string $feature)
     {
-        $this->getRollout()->activate($feature);
+        $rollout->activate($feature);
 
         $this->addFlash('success', sprintf("Feature '%s' is now globally activated", $feature));
 
-        return $this->createRedirectToFeatureListReponse();
+        return $this->redirectToRoute('opensoft_rollout');
     }
 
     /**
-     * @param  string           $feature
+     * @param GroupDefinitionAwareRollout $rollout
+     * @param string $feature
+     *
      * @return RedirectResponse
      */
-    public function deactivateAction($feature)
+    public function deactivateAction(GroupDefinitionAwareRollout $rollout, string $feature)
     {
-        $this->getRollout()->deactivate($feature);
+        $rollout->deactivate($feature);
 
         $this->addFlash('danger', sprintf("Feature '%s' is now globally deactivated", $feature));
 
-        return $this->createRedirectToFeatureListReponse();
+        return $this->redirectToRoute('opensoft_rollout');
     }
 
     /**
-     * @param  string           $feature
+     * @param GroupDefinitionAwareRollout $rollout
+     * @param string $feature
+     *
      * @return RedirectResponse
      */
-    public function incrementPercentageAction($feature)
+    public function incrementPercentageAction(GroupDefinitionAwareRollout $rollout, string $feature)
     {
-        $rollout = $this->getRollout();
         $percentage = $rollout->get($feature)->getPercentage() + 10;
         $rollout->activatePercentage($feature, $percentage);
 
         $this->addFlash('info', sprintf("Feature '%s' percentage changed to %d%% of all users", $feature, $percentage));
 
-        return $this->createRedirectToFeatureListReponse();
+        return $this->redirectToRoute('opensoft_rollout');
     }
 
     /**
-     * @param  string           $feature
+     * @param GroupDefinitionAwareRollout $rollout
+     * @param string $feature
+     *
      * @return RedirectResponse
      */
-    public function decrementPercentageAction($feature)
+    public function decrementPercentageAction(GroupDefinitionAwareRollout $rollout, string $feature)
     {
-        $rollout = $this->getRollout();
         $percentage = $rollout->get($feature)->getPercentage() - 10;
         $rollout->activatePercentage($feature, $percentage);
 
         $this->addFlash('info', sprintf("Feature '%s' percentage changed to %d%% of all users", $feature, $percentage));
 
-        return $this->createRedirectToFeatureListReponse();
+        return $this->redirectToRoute('opensoft_rollout');
     }
 
     /**
-     * @param  string           $feature
-     * @param  string           $group
+     * @param GroupDefinitionAwareRollout $rollout
+     * @param string $feature
+     * @param string $group
+     *
      * @return RedirectResponse
      */
-    public function activateGroupAction($feature, $group)
+    public function activateGroupAction(GroupDefinitionAwareRollout $rollout, string $feature, string $group)
     {
-        $this->getRollout()->activateGroup($feature, $group);
+        $rollout->activateGroup($feature, $group);
 
         $this->addFlash('info', sprintf("Feature '%s' is now active in group '%s'", $feature, $group));
 
-        return $this->createRedirectToFeatureListReponse();
+        return $this->redirectToRoute('opensoft_rollout');
     }
 
     /**
-     * @param  string           $feature
-     * @param  string           $group
+     * @param GroupDefinitionAwareRollout $rollout
+     * @param string $feature
+     * @param string $group
+     *
      * @return RedirectResponse
      */
-    public function deactivateGroupAction($feature, $group)
+    public function deactivateGroupAction(GroupDefinitionAwareRollout $rollout, string $feature, string $group)
     {
-        $this->getRollout()->deactivateGroup($feature, $group);
+        $rollout->deactivateGroup($feature, $group);
 
         $this->addFlash('info', sprintf("Feature '%s' is no longer active in group '%s'", $feature, $group));
 
-        return $this->createRedirectToFeatureListReponse();
-    }
-
-    /**
-     * @param  Request          $request
-     * @param  string           $feature
-     * @return RedirectResponse
-     */
-    public function activateUserAction(Request $request, $feature)
-    {
-        $requestUser = $request->get('user');
-        $user = $this->getRolloutUserProvider()->findByRolloutIdentifier($requestUser);
-
-        if ($user) {
-            $this->getRollout()->activateUser($feature, $user);
-
-            $this->addFlash('info', sprintf("User '%s' was activated in feature '%s'", $user->getRolloutIdentifier(), $feature));
-        } else {
-            $this->addFlash('danger', sprintf("User '%s' not found", $requestUser));
-        }
-
-        return $this->createRedirectToFeatureListReponse();
-    }
-
-    /**
-     * @param  string           $feature
-     * @param  string           $id
-     * @return RedirectResponse
-     */
-    public function deactivateUserAction($feature, $id)
-    {
-        $user = $this->getRolloutUserProvider()->findByRolloutIdentifier($id);
-        $this->getRollout()->deactivateUser($feature, $user);
-
-        $this->addFlash('info', sprintf("User '%s' was deactivated from feature '%s'", $user->getRolloutIdentifier(), $feature));
-
-        return $this->createRedirectToFeatureListReponse();
-    }
-
-    /**
-     * @param  string           $feature
-     * @return RedirectResponse
-     */
-    public function removeAction($feature)
-    {
-        $this->getRollout()->remove($feature);
-
-        $this->addFlash('info', sprintf("Feature '%s' was removed from rollout.", $feature));
-
-        return $this->createRedirectToFeatureListReponse();
+        return $this->redirectToRoute('opensoft_rollout');
     }
 
     /**
      * @param Request $request
+     * @param GroupDefinitionAwareRollout $rollout
+     * @param UserProviderInterface $userProvider
      * @param string $feature
+     *
      * @return RedirectResponse
      */
-    public function setRequestParamAction(Request $request, $feature)
-    {
-        $requestParam = $request->get('requestParam');
-        if ($requestParam === null) {
-            $this->addFlash('danger', 'Missing "requestParam" value');
-            return $this->createRedirectToFeatureListReponse();
+    public function activateUserAction(
+        Request $request,
+        GroupDefinitionAwareRollout $rollout,
+        UserProviderInterface $userProvider,
+        string $feature
+    ) {
+        $requestUser = $request->get('user');
+        $user = $userProvider->findByRolloutIdentifier($requestUser);
+
+        if ($user) {
+            $rollout->activateUser($feature, $user);
+
+            $this->addFlash(
+                'info',
+                sprintf(
+                    "User '%s' was activated in feature '%s'",
+                    $user->getRolloutIdentifier(),
+                    $feature
+                )
+            );
+        } else {
+            $this->addFlash('danger', sprintf("User '%s' not found", $requestUser));
         }
 
-        $this->getRollout()->activateRequestParam($feature, $requestParam);
+        return $this->redirectToRoute('opensoft_rollout');
+    }
+
+    /**
+     * @param GroupDefinitionAwareRollout $rollout
+     * @param UserProviderInterface $userProvider
+     * @param string $feature
+     * @param string $id
+     *
+     * @return RedirectResponse
+     */
+    public function deactivateUserAction(
+        GroupDefinitionAwareRollout $rollout,
+        UserProviderInterface $userProvider,
+        string $feature,
+        string $id
+    ) {
+        $user = $userProvider->findByRolloutIdentifier($id);
+        $rollout->deactivateUser($feature, $user);
+
+        $this->addFlash(
+            'info',
+            sprintf(
+                "User '%s' was deactivated from feature '%s'",
+                $user->getRolloutIdentifier(),
+                $feature
+            )
+        );
+
+        return $this->redirectToRoute('opensoft_rollout');
+    }
+
+    /**
+     * @param GroupDefinitionAwareRollout $rollout
+     * @param string $feature
+     *
+     * @return RedirectResponse
+     */
+    public function removeAction(GroupDefinitionAwareRollout $rollout, string $feature)
+    {
+        $rollout->remove($feature);
+
+        $this->addFlash('info', sprintf("Feature '%s' was removed from rollout.", $feature));
+
+        return $this->redirectToRoute('opensoft_rollout');
+    }
+
+    /**
+     * @param Request $request
+     * @param GroupDefinitionAwareRollout $rollout
+     * @param string $feature
+     *
+     * @return RedirectResponse
+     */
+    public function setRequestParamAction(Request $request, GroupDefinitionAwareRollout $rollout, string $feature)
+    {
+        $requestParam = $request->get('requestParam');
+
+        if ($requestParam === null) {
+            $this->addFlash('danger', 'Missing "requestParam" value');
+            
+            return $this->redirectToRoute('opensoft_rollout');
+        }
+
+        $rollout->activateRequestParam($feature, $requestParam);
 
         $this->addFlash('info', sprintf('Feature "%s" requestParam changed to "%s"', $feature, $requestParam));
 
-        return $this->createRedirectToFeatureListReponse();
-    }
-
-    /**
-     * @return Rollout
-     */
-    private function getRollout()
-    {
-        return $this->container->get('rollout');
-    }
-
-    /**
-     * @return UserProviderInterface
-     */
-    private function getRolloutUserProvider()
-    {
-        return $this->container->get('rollout.user_provider');
-    }
-
-    /**
-     * Helper for adding flash messages
-     *
-     * @param string $type
-     * @param string $message
-     */
-    protected function addFlash($type, $message)
-    {
-        $this->container->get('session')->getFlashBag()->add($type, $message);
-    }
-
-    /**
-     * @return RedirectResponse
-     */
-    private function createRedirectToFeatureListReponse()
-    {
-        return new RedirectResponse($this->container->get('router')->generate('opensoft_rollout'));
+        return $this->redirectToRoute('opensoft_rollout');
     }
 }

--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -47,7 +47,7 @@ class DefaultController extends Controller
      *
      * @return RedirectResponse
      */
-    public function activateAction(string $feature)
+    public function activateAction($feature)
     {
         $this->rollout->activate($feature);
 
@@ -61,7 +61,7 @@ class DefaultController extends Controller
      *
      * @return RedirectResponse
      */
-    public function deactivateAction(string $feature)
+    public function deactivateAction($feature)
     {
         $this->rollout->deactivate($feature);
 
@@ -75,7 +75,7 @@ class DefaultController extends Controller
      *
      * @return RedirectResponse
      */
-    public function incrementPercentageAction(string $feature)
+    public function incrementPercentageAction($feature)
     {
         return $this->changePercentage($feature, 10);
     }
@@ -85,7 +85,7 @@ class DefaultController extends Controller
      *
      * @return RedirectResponse
      */
-    public function decrementPercentageAction(string $feature)
+    public function decrementPercentageAction($feature)
     {
         return $this->changePercentage($feature, -10);
     }
@@ -96,7 +96,7 @@ class DefaultController extends Controller
      *
      * @return RedirectResponse
      */
-    public function activateGroupAction(string $feature, string $group)
+    public function activateGroupAction($feature, $group)
     {
         $this->rollout->activateGroup($feature, $group);
 
@@ -111,7 +111,7 @@ class DefaultController extends Controller
      *
      * @return RedirectResponse
      */
-    public function deactivateGroupAction(string $feature, string $group)
+    public function deactivateGroupAction($feature, $group)
     {
         $this->rollout->deactivateGroup($feature, $group);
 
@@ -126,7 +126,7 @@ class DefaultController extends Controller
      *
      * @return RedirectResponse
      */
-    public function activateUserAction(Request $request, string $feature) 
+    public function activateUserAction(Request $request, $feature)
     {
         $requestUser = $request->get('user');
         $user = $this->userProvider->findByRolloutIdentifier($requestUser);
@@ -155,7 +155,7 @@ class DefaultController extends Controller
      *
      * @return RedirectResponse
      */
-    public function deactivateUserAction(string $feature, string $id) 
+    public function deactivateUserAction($feature, $id)
     {
         $user = $this->userProvider->findByRolloutIdentifier($id);
 
@@ -182,7 +182,7 @@ class DefaultController extends Controller
      *
      * @return RedirectResponse
      */
-    public function removeAction(string $feature)
+    public function removeAction($feature)
     {
         $this->rollout->remove($feature);
 
@@ -197,7 +197,7 @@ class DefaultController extends Controller
      *
      * @return RedirectResponse
      */
-    public function setRequestParamAction(Request $request, string $feature)
+    public function setRequestParamAction(Request $request, $feature)
     {
         $requestParam = $request->get('requestParam');
 
@@ -222,7 +222,7 @@ class DefaultController extends Controller
      *
      * @return RedirectResponse
      */
-    private function changePercentage(string $feature, int $increment)
+    private function changePercentage($feature, $increment)
     {
         $percentage = $this->rollout->get($feature)->getPercentage() + $increment;
         $this->rollout->activatePercentage($feature, $percentage);

--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -39,7 +39,7 @@ class DefaultController extends AbstractController
      */
     public function indexAction()
     {
-        return $this->render('@OpensoftRolloutBundle/Default/index.html.twig', array('rollout' => $this->rollout));
+        return $this->render('@OpensoftRollout/Default/index.html.twig', array('rollout' => $this->rollout));
     }
 
     /**

--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -39,7 +39,7 @@ class DefaultController extends AbstractController
      */
     public function indexAction()
     {
-        return $this->render('OpensoftRolloutBundle:Default:index.html.twig', array('rollout' => $this->rollout));
+        return $this->render('@OpensoftRolloutBundle/Default/index.html.twig', array('rollout' => $this->rollout));
     }
 
     /**

--- a/DependencyInjection/Compiler/AddGroupDefinitionPass.php
+++ b/DependencyInjection/Compiler/AddGroupDefinitionPass.php
@@ -2,6 +2,7 @@
 
 namespace Opensoft\RolloutBundle\DependencyInjection\Compiler;
 
+use Opensoft\RolloutBundle\Rollout\GroupDefinitionAwareRollout;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -20,11 +21,12 @@ class AddGroupDefinitionPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('rollout')) {
+        if (!$container->hasDefinition(GroupDefinitionAwareRollout::class)) {
             return;
         }
 
-        $definition = $container->getDefinition('rollout');
+        $definition = $container->getDefinition(GroupDefinitionAwareRollout::class);
+
         foreach ($container->findTaggedServiceIds('rollout.group') as $id => $attributes) {
             $definition->addMethodCall('addGroupDefinition', array(new Reference($id)));
         }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,7 +27,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('user_provider_service')->isRequired()->end()
-                ->scalarNode('storage_service')->defaultValue('rollout.storage.array_storage')->end()
+                ->scalarNode('storage_service')->defaultValue('Opensoft\Rollout\Storage\ArrayStorage')->end()
             ->end()
         ;
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('opensoft_rollout');
+        $treeBuilder = new TreeBuilder('opensoft_rollout');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('opensoft_rollout');
+        }
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,10 +26,9 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('user_provider_service')->isRequired()->end()
-                ->scalarNode('storage_service')->defaultValue('Opensoft\Rollout\Storage\ArrayStorage')->end()
-            ->end()
-        ;
+            ->scalarNode('user_provider_service')->isRequired()->end()
+            ->scalarNode('storage_service')->defaultValue('Opensoft\Rollout\Storage\ArrayStorage')->end()
+            ->end();
 
         return $treeBuilder;
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,11 +17,11 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder('opensoft_rollout');
-
-        if (method_exists($treeBuilder, 'getRootNode')) {
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder('opensoft_rollout');
             $rootNode = $treeBuilder->getRootNode();
         } else {
+            $treeBuilder = new TreeBuilder();
             $rootNode = $treeBuilder->root('opensoft_rollout');
         }
 

--- a/DependencyInjection/OpensoftRolloutExtension.php
+++ b/DependencyInjection/OpensoftRolloutExtension.php
@@ -2,10 +2,10 @@
 
 namespace Opensoft\RolloutBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration

--- a/DependencyInjection/OpensoftRolloutExtension.php
+++ b/DependencyInjection/OpensoftRolloutExtension.php
@@ -24,8 +24,8 @@ class OpensoftRolloutExtension extends Extension
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
-        $container->setAlias('rollout.user_provider', $config['user_provider_service']);
-        $container->setAlias('rollout.storage', $config['storage_service']);
+        $container->setAlias('Opensoft\RolloutBundle\Rollout\UserProviderInterface', $config['user_provider_service']);
+        $container->setAlias('Opensoft\Rollout\Storage\StorageInterface', $config['storage_service']);
 
         $loader->load('services.xml');
     }

--- a/Entity/Feature.php
+++ b/Entity/Feature.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
  * @author Richard Fullmer <richard.fullmer@opensoftdev.com>
  *
  * @ORM\Table(name="rollout_feature")
- * @ORM\Entity()
+ * @ORM\Entity
  */
 class Feature
 {

--- a/README.md
+++ b/README.md
@@ -26,17 +26,16 @@ new Opensoft\RolloutBundle\OpensoftRolloutBundle(),
 
 ### 2) Configuration
 
-Add the following to your configuration
+Add the following to your configuration (supports auto-wiring)
 
 ```yaml
 opensoft_rollout:
-    user_provider_service: [YOUR USER PROVIDER SERVICE ID]
+    user_provider_service: [YOUR USER PROVIDER SERVICE]
     storage_service: [YOUR STORAGE SERVICE FOR ROLLOUT]
 ```
 
-* `user_provider_service`: If you are using one of the default Symfony user providers you can get the service ID by running `bin/console debug:container provider` e.g: `security.user.provider.ldap`
-* `storage_service`: Defaults to `rollout.storage.array_storage`, but you can also use the included `rollout.storage.doctrine_orm_storage` or create your own (see below for implementation)
-
+* `user_provider_service`: Add the service id (generally the FQDN with auto-wiring) of the UserProvider to which you added the Rollout `UserProviderInterface`
+* `storage_service`: Defaults to `Opensoft\Rollout\Storage\ArrayStorage`, but you can also use the included `Opensoft\RolloutBundle\Storage\Doctrine\DoctrineORMStorage` or create your own (see below for implementation)
 
 ### 3) Implement Interfaces
 

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -2,54 +2,54 @@
 opensoft_rollout:
     path: /
     defaults:
-        _controller: OpensoftRolloutBundle:Default:index
+        _controller: Opensoft\RolloutBundle\Controller\DefaultController::indexAction
 
 opensoft_rollout_feature_activate:
     path: /{feature}/activate
     defaults:
-        _controller: OpensoftRolloutBundle:Default:activate
+        _controller: Opensoft\RolloutBundle\Controller\DefaultController::activateAction
 
 opensoft_rollout_feature_deactivate:
     path: /{feature}/deactivate
     defaults:
-        _controller: OpensoftRolloutBundle:Default:deactivate
+        _controller: Opensoft\RolloutBundle\Controller\DefaultController::deactivateAction
 
 opensoft_rollout_feature_increment_percentage:
     path: /{feature}/increment-percentage
     defaults:
-        _controller: OpensoftRolloutBundle:Default:incrementPercentage
+        _controller: Opensoft\RolloutBundle\Controller\DefaultController::incrementPercentageAction
 
 opensoft_rollout_feature_decrement_percentage:
     path: /{feature}/decrement-percentage
     defaults:
-        _controller: OpensoftRolloutBundle:Default:decrementPercentage
+        _controller: Opensoft\RolloutBundle\Controller\DefaultController::decrementPercentageAction
 
 opensoft_rollout_feature_activate_group:
     path: /{feature}/activate-group/{group}
     defaults:
-        _controller: OpensoftRolloutBundle:Default:activateGroup
+        _controller: Opensoft\RolloutBundle\Controller\DefaultController::activateGroupAction
 
 opensoft_rollout_feature_deactivate_group:
     path: /{feature}/deactivate-group/{group}
     defaults:
-        _controller: OpensoftRolloutBundle:Default:deactivateGroup
+        _controller: Opensoft\RolloutBundle\Controller\DefaultController::deactivateGroupAction
 
 opensoft_rollout_feature_activate_user:
     path: /{feature}/activate-user
     defaults:
-        _controller: OpensoftRolloutBundle:Default:activateUser
+        _controller: Opensoft\RolloutBundle\Controller\DefaultController::activateUserAction
 
 opensoft_rollout_feature_deactivate_user:
     path: /{feature}/deactivate-user/{id}
     defaults:
-        _controller: OpensoftRolloutBundle:Default:deactivateUser
+        _controller: Opensoft\RolloutBundle\Controller\DefaultController::deactivateUserAction
 
 opensoft_rollout_feature_remove:
     path: /{feature}/remove
     defaults:
-        _controller: OpensoftRolloutBundle:Default:remove
+        _controller: Opensoft\RolloutBundle\Controller\DefaultController::removeAction
 
 opensoft_rollout_feature_set_request_param:
     path: /{feature}/set-request-param
     defaults:
-        _controller: OpensoftRolloutBundle:Default:setRequestParam
+        _controller: Opensoft\RolloutBundle\Controller\DefaultController::setRequestParamAction

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,34 +4,17 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="rollout.class">Opensoft\RolloutBundle\Rollout\GroupDefinitionAwareRollout</parameter>
-
-        <parameter key="rollout.storage.doctrine_orm_storage.class">Opensoft\RolloutBundle\Storage\Doctrine\DoctrineORMStorage</parameter>
-        <parameter key="rollout.storage.array_storage.class">Opensoft\Rollout\Storage\ArrayStorage</parameter>
-
-        <parameter key="rollout.twig_extension.class">Opensoft\RolloutBundle\Twig\Extension\RolloutExtension</parameter>
-    </parameters>
-
     <services>
-        <service id="rollout" class="%rollout.class%">
-            <argument type="service" id="rollout.storage" />
-        </service>
+        <!-- Default configuration for services in *this* file -->
+        <defaults autowire="true" autoconfigure="true" public="false" />
 
-        <!-- Storages -->
-        <service id="rollout.storage.array_storage" class="%rollout.storage.array_storage.class%">
+        <prototype namespace="Opensoft\RolloutBundle\" resource="../../{Twig,Rollout,Storage,Controller}" />
 
-        </service>
+         <!-- Explicitly configure these services -->
+        <service id="Opensoft\Rollout\Storage\ArrayStorage"></service>
 
-        <service id="rollout.storage.doctrine_orm_storage" class="%rollout.storage.doctrine_orm_storage.class%">
-            <argument type="service" id="doctrine.orm.default_entity_manager" />
-            <argument>OpensoftRolloutBundle:Feature</argument>
-        </service>
-
-        <!-- Template Extensions -->
-        <service id="rollout.twig_extension" class="%rollout.twig_extension.class%">
-            <tag name="twig.extension" />
-            <argument type="service" id="rollout" />
+        <service id="Opensoft\RolloutBundle\Storage\Doctrine\DoctrineORMStorage">
+            <argument key="$class">OpensoftRolloutBundle:Feature</argument>
         </service>
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -16,5 +16,13 @@
         <service id="Opensoft\RolloutBundle\Storage\Doctrine\DoctrineORMStorage">
             <argument key="$class">OpensoftRolloutBundle:Feature</argument>
         </service>
+
+        <!-- Add aliases for BC -->
+        <service
+            alias="Opensoft\Rollout\Storage\ArrayStorage"
+            id="rollout.storage.array_storage"></service>
+        <service
+            alias="Opensoft\RolloutBundle\Storage\Doctrine\DoctrineORMStorage"
+            id="rollout.storage.doctrine_orm_storage"></service>
     </services>
 </container>

--- a/Resources/views/Default/index.html.twig
+++ b/Resources/views/Default/index.html.twig
@@ -194,7 +194,7 @@
                     <h4>Status</h4>
                     <p>Shows a status symbol based on how much of the feature is rolled out</p>
                     <h4>Name</h4>
-                    <p>The feature name.  This key is use in the code and must match exactly.</p>
+                    <p>The feature name.  This key is used in the code and must match exactly.</p>
                     <h4>Priorities</h4>
                     <p>When calculating if a feature is enabled, a list of priorities will be matched before the first one returns true.</p>
                     <dl class="dl-horizontal">
@@ -203,9 +203,9 @@
                         <dt>Percentage</dt>
                         <dd>Controls the percentage of logged in users that will have this feature activated for them.</dd>
                         <dt>Users</dt>
-                        <dd>Provide a list of individual users which have this feature active</dd>
+                        <dd>Provides a list of individual users which have this feature active</dd>
                         <dt>Groups of users</dt>
-                        <dd>Define custom groups that are matched dynamically</dd>
+                        <dd>Defines custom groups that are matched dynamically</dd>
                     </dl>
                     <h4>Global Actions</h4>
                     <p>

--- a/Resources/views/Default/index.html.twig
+++ b/Resources/views/Default/index.html.twig
@@ -1,4 +1,4 @@
-{% extends "OpensoftRolloutBundle::layout.html.twig" %}
+{% extends "@OpensoftRolloutBundle/layout.html.twig" %}
 
 {% block rollout_content %}
 <div class="page-header">

--- a/Resources/views/Default/index.html.twig
+++ b/Resources/views/Default/index.html.twig
@@ -1,4 +1,4 @@
-{% extends "@OpensoftRolloutBundle/layout.html.twig" %}
+{% extends "@OpensoftRollout/layout.html.twig" %}
 
 {% block rollout_content %}
 <div class="page-header">

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -1,15 +1,12 @@
 <html>
+    <head>
+        <title>Feature Flippers</title>
+        <link href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
+        <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
+        <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+    </head>
 
-<head>
-    <title>Feature Flippers</title>
-
-    <link href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
-    <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
-</head>
-
-<body>
-{% block rollout_content %}{% endblock %}
-</body>
-
+    <body>
+        {% block rollout_content %}{% endblock %}
+    </body>
 </html>

--- a/Rollout/UserProviderInterface.php
+++ b/Rollout/UserProviderInterface.php
@@ -10,7 +10,7 @@ use Opensoft\Rollout\RolloutUserInterface;
 interface UserProviderInterface
 {
     /**
-     * @param  mixed                     $id
+     * @param mixed $id
      * @return RolloutUserInterface|null
      */
     public function findByRolloutIdentifier($id);

--- a/Storage/Doctrine/DoctrineORMStorage.php
+++ b/Storage/Doctrine/DoctrineORMStorage.php
@@ -28,7 +28,7 @@ class DoctrineORMStorage implements StorageInterface
 
     /**
      * @param EntityManagerInterface $em
-     * @param string                 $class
+     * @param string $class
      */
     public function __construct(EntityManagerInterface $em, $class)
     {
@@ -38,7 +38,8 @@ class DoctrineORMStorage implements StorageInterface
     }
 
     /**
-     * @param  string     $key
+     * @param string key
+     *
      * @return mixed|null Null if the value is not found
      */
     public function get($key)
@@ -54,7 +55,7 @@ class DoctrineORMStorage implements StorageInterface
 
     /**
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      */
     public function set($key, $value)
     {

--- a/Storage/Doctrine/DoctrineORMStorage.php
+++ b/Storage/Doctrine/DoctrineORMStorage.php
@@ -11,7 +11,6 @@ use Opensoft\RolloutBundle\Entity\Feature;
  */
 class DoctrineORMStorage implements StorageInterface
 {
-
     /**
      * @var \Doctrine\ORM\EntityManager
      */

--- a/Storage/Doctrine/DoctrineORMStorage.php
+++ b/Storage/Doctrine/DoctrineORMStorage.php
@@ -2,7 +2,7 @@
 
 namespace Opensoft\RolloutBundle\Storage\Doctrine;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Opensoft\Rollout\Storage\StorageInterface;
 use Opensoft\RolloutBundle\Entity\Feature;
 
@@ -12,7 +12,7 @@ use Opensoft\RolloutBundle\Entity\Feature;
 class DoctrineORMStorage implements StorageInterface
 {
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     protected $em;
 
@@ -27,10 +27,10 @@ class DoctrineORMStorage implements StorageInterface
     protected $class;
 
     /**
-     * @param EntityManager $em
-     * @param string        $class
+     * @param EntityManagerInterface $em
+     * @param string                 $class
      */
-    public function __construct(EntityManager $em, $class)
+    public function __construct(EntityManagerInterface $em, $class)
     {
         $this->em = $em;
         $this->repository = $em->getRepository($class);

--- a/Tests/Rollout/GroupDefinitionAwareRolloutTest.php
+++ b/Tests/Rollout/GroupDefinitionAwareRolloutTest.php
@@ -36,7 +36,10 @@ class User implements RolloutUserInterface
 {
     public $name;
 
-    public function __construct($name)
+    /**
+     * @param string $name
+     */
+    public function __construct(string $name)
     {
         $this->name = $name;
     }
@@ -48,5 +51,4 @@ class User implements RolloutUserInterface
     {
         return '';
     }
-
 }

--- a/Tests/Rollout/GroupDefinitionAwareRolloutTest.php
+++ b/Tests/Rollout/GroupDefinitionAwareRolloutTest.php
@@ -39,7 +39,7 @@ class User implements RolloutUserInterface
     /**
      * @param string $name
      */
-    public function __construct(string $name)
+    public function __construct($name)
     {
         $this->name = $name;
     }

--- a/Twig/Extension/RolloutExtension.php
+++ b/Twig/Extension/RolloutExtension.php
@@ -2,8 +2,8 @@
 
 namespace Opensoft\RolloutBundle\Twig\Extension;
 
-use Opensoft\Rollout\Rollout;
 use Opensoft\Rollout\RolloutUserInterface;
+use Opensoft\RolloutBundle\Rollout\GroupDefinitionAwareRollout;
 
 /**
  * @author Richard Fullmer <richard.fullmer@opensoftdev.com>
@@ -11,14 +11,14 @@ use Opensoft\Rollout\RolloutUserInterface;
 class RolloutExtension extends \Twig_Extension
 {
     /**
-     * @var Rollout
+     * @var GroupDefinitionAwareRollout
      */
     private $rollout;
 
     /**
-     * @param Rollout $rollout
+     * @param GroupDefinitionAwareRollout $rollout
      */
-    public function __construct(Rollout $rollout)
+    public function __construct(GroupDefinitionAwareRollout $rollout)
     {
         $this->rollout = $rollout;
     }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "opensoft/rollout-bundle",
-    "description": "A Symfony2 Bundle for opensoft/rollout",
+    "description": "A Symfony3 Bundle for opensoft/rollout",
     "license": "MIT",
     "authors": [
         {
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3",
-        "symfony/framework-bundle": "~2.1|^3.0",
+        "php": "^5.5.9|>=7.0.8",
+        "symfony/framework-bundle": "^3.0",
         "opensoft/rollout": "~2.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "opensoft/rollout-bundle",
-    "description": "A Symfony3 Bundle for opensoft/rollout",
+    "description": "A Symfony2 Bundle for opensoft/rollout",
     "license": "MIT",
     "authors": [
         {
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "php": "^5.5.9|>=7.0.8",
-        "symfony/framework-bundle": "^3.0",
+        "php": ">=5.3",
+        "symfony/framework-bundle": "~2.1|^3.0",
         "opensoft/rollout": "~2.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "opensoft/rollout-bundle",
-    "description": "A Symfony2 Bundle for opensoft/rollout",
+    "description": "A Symfony2/3/4 Bundle for opensoft/rollout",
     "license": "MIT",
     "authors": [
         {
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3",
-        "symfony/framework-bundle": "~2.1|^3.0",
+        "symfony/framework-bundle": "~2.1|^3.0|^4.0",
         "opensoft/rollout": "~2.1"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,7 +14,7 @@
     bootstrap                   = "vendor/autoload.php" >
 
     <testsuites>
-        <testsuite name="Symfony3 Rollout Bundle Test Suite">
+        <testsuite name="Symfony2 Rollout Bundle Test Suite">
             <directory suffix="Test.php">./Tests</directory>
         </testsuite>
     </testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,7 +14,7 @@
     bootstrap                   = "vendor/autoload.php" >
 
     <testsuites>
-        <testsuite name="Symfony2 Rollout Bundle Test Suite">
+        <testsuite name="Symfony3 Rollout Bundle Test Suite">
             <directory suffix="Test.php">./Tests</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
Symfony 3.4+ makes all services private by default in preparation for Symfony 4.

This PR auto-wires the Rollout services, which fixes the issue of not being able to add users to a feature flag in Symfony 3.4.

Also updates the controller to use auto-wired services and the built in Symfony controller methods - this removes all deprecated warnings from the Profiler log.

Auto-wiring has been in Symfony since 2, so this maintains BC (plus added in the old alias to maintain config BC).